### PR TITLE
Use Build Tools GitLab URL instead of hardcoded gitlab.com.

### DIFF
--- a/src/ServiceProviders/RepositoryProviders/GitLab/GitLabProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/GitLab/GitLabProvider.php
@@ -9,7 +9,8 @@ class GitLabProvider extends BuildToolsGitLabProvider implements GitProvider {
 
   public function cloneRepository($target_project, $destination) {
     $gitlab_token = $this->token();
-    $remote_url = "https://gitlab-ci-token:$gitlab_token@gitlab.com/${target_project}.git";
+    $gitlab_url = $this->getGitLabUrl();
+    $remote_url = "https://gitlab-ci-token:$gitlab_token@$gitlab_url/${target_project}.git";
     $this->execWithRedaction("git clone {remote} $destination", ['remote' => $remote_url], ['remote' => $target_project]);
   }
 


### PR DESCRIPTION
The Build Tools GitLab provider provides a function to retrieve the GitLab URL -- this handles those people who self-host GitLab or falls back to gitlab.com for those using the SaaS solution. We should use that same function here instead of hard-coding gitlab.com.