### PR TITLE
Set pipefail to properly report status of composer update

### DIFF
--- a/src/Commands/ComposerLockUpdateCommand.php
+++ b/src/Commands/ComposerLockUpdateCommand.php
@@ -174,7 +174,7 @@ EOT;
    */
   protected function runComposerUpdate() {
     $args = getenv('CLU_COMPOSER_UPDATE_ARGS') ?: '--no-progress --no-dev --no-interaction';
-    return $this->exec("composer update --working-dir={$this->working_dir} $args 2>&1 | tee {$this->working_dir}/vendor/update.log");
+    return $this->exec("set -o pipefail && composer update --working-dir={$this->working_dir} $args 2>&1 | tee {$this->working_dir}/vendor/update.log");
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/pantheon-systems/terminus-clu-plugin/issues/8.

See https://github.com/danielbachhuber/composer-lock-updater/issues/39 for more information.