### PR TITLE
Account for custom URLs for self-hosted GitLab when selecting git provider

### DIFF
--- a/src/ServiceProviders/RepositoryProviders/CluGitTrait.php
+++ b/src/ServiceProviders/RepositoryProviders/CluGitTrait.php
@@ -2,6 +2,8 @@
 
 namespace Pantheon\TerminusClu\ServiceProviders\RepositoryProviders;
 
+use Pantheon\TerminusBuildTools\API\GitLab\GitLabAPI;
+
 trait CluGitTrait {
 
   public function createGitCluProvider($git_provider_class_or_alias) {
@@ -37,9 +39,12 @@ trait CluGitTrait {
     if (false !== strpos($url, 'bitbucket')) {
       return $this->createGitCluProvider('\Pantheon\TerminusClu\ServiceProviders\RepositoryProviders\Bitbucket\BitbucketProvider');
     }
-    if (false !== strpos($url, 'gitlab')) {
+
+    $gitlab_url = GitLabAPI::determineGitLabUrl($this->config);
+    if (false !== strpos($url, (empty($gitlab_url) ? 'gitlab' : $gitlab_url))) {
       return $this->createGitCluProvider('\Pantheon\TerminusClu\ServiceProviders\RepositoryProviders\GitLab\GitLabProvider');
     }
+
     if (false !== strpos($url, 'github')) {
       return $this->createGitCluProvider('\Pantheon\TerminusClu\ServiceProviders\RepositoryProviders\GitHub\GitHubProvider');
     }

--- a/src/ServiceProviders/RepositoryProviders/CluGitTrait.php
+++ b/src/ServiceProviders/RepositoryProviders/CluGitTrait.php
@@ -40,8 +40,7 @@ trait CluGitTrait {
       return $this->createGitCluProvider('\Pantheon\TerminusClu\ServiceProviders\RepositoryProviders\Bitbucket\BitbucketProvider');
     }
 
-    $gitlab_url = GitLabAPI::determineGitLabUrl($this->config);
-    if (false !== strpos($url, (empty($gitlab_url) ? 'gitlab' : $gitlab_url))) {
+    if (false !== strpos($url, GitLabAPI::determineGitLabUrl($this->config))) {
       return $this->createGitCluProvider('\Pantheon\TerminusClu\ServiceProviders\RepositoryProviders\GitLab\GitLabProvider');
     }
 


### PR DESCRIPTION
Plugin currently fails to infer a provider for projects using self-hosted GitLab because it does not account for custom GitLab URLs. Resolve by using the helper method from terminus-build-tools to get the custom URL or fallback to 'gitlab.com'. 