### PR TITLE
Fix PHP 8.2:  string interpolation deprecations

### DIFF
--- a/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/Bitbucket/BitbucketProvider.php
@@ -9,7 +9,7 @@ class BitbucketProvider extends BuildToolsBitbucketProvider implements GitProvid
 
   public function cloneRepository($target_project, $destination) {
     $bitbucket_token = $this->token();
-    $remote_url = "https://$bitbucket_token@bitbucket.org/${target_project}.git";
+    $remote_url = "https://$bitbucket_token@bitbucket.org/$target_project.git";
     $this->execWithRedaction("git clone {remote} $destination", ['remote' => $remote_url], ['remote' => $target_project]);
   }
 

--- a/src/ServiceProviders/RepositoryProviders/GitHub/GitHubProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/GitHub/GitHubProvider.php
@@ -9,7 +9,7 @@ class GitHubProvider extends BuildToolsGitHubProvider implements GitProvider {
 
   public function cloneRepository($target_project, $destination) {
     $github_token = $this->token();
-    $remote_url = "https://${github_token}:x-oauth-basic@github.com/${target_project}.git";
+    $remote_url = "https://$github_token:x-oauth-basic@github.com/$target_project.git";
     $this->execWithRedaction("git clone {remote} $destination", ['remote' => $remote_url], ['remote' => $target_project]);
   }
 

--- a/src/ServiceProviders/RepositoryProviders/GitLab/GitLabProvider.php
+++ b/src/ServiceProviders/RepositoryProviders/GitLab/GitLabProvider.php
@@ -10,7 +10,7 @@ class GitLabProvider extends BuildToolsGitLabProvider implements GitProvider {
   public function cloneRepository($target_project, $destination) {
     $gitlab_token = $this->token();
     $gitlab_url = $this->getGitLabUrl();
-    $remote_url = "https://gitlab-ci-token:$gitlab_token@$gitlab_url/${target_project}.git";
+    $remote_url = "https://gitlab-ci-token:$gitlab_token@$gitlab_url/$target_project.git";
     $this->execWithRedaction("git clone {remote} $destination", ['remote' => $remote_url], ['remote' => $target_project]);
   }
 


### PR DESCRIPTION
I’m seeing the following deprecated notices in my logs:

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /home/tester/.terminus/terminus-dependencies-**********/vendor/pantheon-systems/terminus-clu-plugin/src/ServiceProviders/RepositoryProviders/GitHub/GitHubProvider.php on line 12

This is because I’m using PHP 8.2 and it is deprecated:
https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation